### PR TITLE
feat: Add real-time GPU/VRAM metrics monitoring and display

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,11 @@
       "Bash(rm:*)",
       "Bash(pnpm install:*)",
       "Bash(pnpm view:*)",
-      "Bash(pnpm build:*)"
+      "Bash(pnpm build:*)",
+      "mcp__github__create_issue",
+      "mcp__github__add_issue_comment",
+      "mcp__github__get_issue",
+      "Bash(git checkout:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,6 @@ Models are routed using this hierarchy:
 - Ensure all `polyllamaX` services can resolve each other via Docker networks
 - Check that nginx upstream pool matches actual running services
 - Verify GPU assignments in container environment variables
+
+## Development Guidelines
+- We use pnpm NOT npm

--- a/builder/nginx.conf.j2
+++ b/builder/nginx.conf.j2
@@ -7,6 +7,9 @@ lua_package_path "/usr/local/openresty/lualib/?.lua;;";
 # Create a shared dictionary to store environment variables
 lua_shared_dict env_vars 1m;
 
+# Create a shared dictionary to store GPU metrics
+lua_shared_dict gpu_metrics 5m;
+
 # Initialize environment variables in the main Nginx process
 init_by_lua_block {
     local env_vars = ngx.shared.env_vars
@@ -23,12 +26,119 @@ init_by_lua_block {
 init_worker_by_lua_block {
     local model_router = require "model_router"
     local env_vars = ngx.shared.env_vars
+    local cjson = require "cjson"
     
     -- Initialize model router
     
     local ok, err = ngx.timer.every(3, model_router.update_model_mappings)
     if not ok then
         ngx.log(ngx.ERR, "Failed to create timer: ", err)
+    end
+    
+    -- Function to collect GPU metrics
+    local function collect_gpu_metrics()
+        local gpu_metrics = ngx.shared.gpu_metrics
+        local http = require "resty.http"
+        
+        -- Instance to GPU mapping
+        local instance_gpu_mapping = {
+{% for instance in ollama_instances %}
+{% if instance.gpu_indices %}
+            ["polyllama{{ instance.number }}"] = {
+                gpu_indices = { {{ instance.gpu_indices }} },
+                gpu_group_index = {{ instance.gpu_group_index }}
+            },
+{% endif %}
+{% endfor %}
+        }
+        
+        -- Collect metrics from each instance's metrics endpoint
+        for instance_name, gpu_info in pairs(instance_gpu_mapping) do
+            local httpc = http.new()
+            httpc:set_timeout(2000)  -- 2 second timeout
+            
+            local res, err = httpc:request_uri("http://" .. instance_name .. ":11435/metrics/gpu", {
+                method = "GET"
+            })
+            
+            if res and res.status == 200 then
+                local success, device_metrics = pcall(cjson.decode, res.body)
+                if success and device_metrics then
+                    -- Store metrics for each GPU device
+                    for _, metric in ipairs(device_metrics) do
+                        metric.timestamp = ngx.time()
+                        gpu_metrics:set("gpu:" .. metric.index, cjson.encode(metric), 10)
+                    end
+                else
+                    ngx.log(ngx.ERR, "Failed to parse metrics from " .. instance_name)
+                end
+            else
+                ngx.log(ngx.ERR, "Failed to fetch metrics from " .. instance_name .. ": " .. (err or "unknown error"))
+            end
+        end
+        
+        -- Collect CPU metrics for CPU-only instances
+        local instance_mapping = {
+{% for instance in ollama_instances %}
+            ["polyllama{{ instance.number }}"] = {
+                gpu_group_index = {{ instance.gpu_group_index if instance.gpu_indices else -1 }},
+                has_gpu = {{ "true" if instance.gpu_indices else "false" }}
+            },
+{% endfor %}
+        }
+        
+        -- Collect CPU metrics for CPU-only instances
+        for instance_name, config in pairs(instance_mapping) do
+            if not config.has_gpu then
+                -- Get CPU and memory info
+                local cpu_handle = io.popen("grep 'cpu ' /proc/stat 2>/dev/null | head -n1")
+                local mem_handle = io.popen("free -m 2>/dev/null | grep '^Mem:'")
+                
+                if cpu_handle and mem_handle then
+                    local cpu_output = cpu_handle:read("*a")
+                    local mem_output = mem_handle:read("*a")
+                    cpu_handle:close()
+                    mem_handle:close()
+                    
+                    -- Parse memory usage
+                    local mem_total, mem_used = mem_output:match("Mem:%s+(%d+)%s+(%d+)")
+                    
+                    if mem_total then
+                        -- Get CPU temperature if available
+                        local temp = nil
+                        local temp_handle = io.popen("cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null")
+                        if temp_handle then
+                            local temp_output = temp_handle:read("*a")
+                            temp_handle:close()
+                            if temp_output and temp_output ~= "" then
+                                temp = tonumber(temp_output) / 1000  -- Convert from millidegrees
+                            end
+                        end
+                        
+                        local metrics = {
+                            memory_used = tonumber(mem_used),
+                            memory_total = tonumber(mem_total),
+                            temperature = temp,
+                            is_cpu_instance = true,
+                            timestamp = ngx.time()
+                        }
+                        
+                        -- Store CPU metrics
+                        gpu_metrics:set("cpu:" .. instance_name, cjson.encode(metrics), 10)
+                    end
+                end
+            end
+        end
+    end
+    
+    -- Set up timer to collect metrics every 2 seconds (only on first worker)
+    if ngx.worker.id() == 0 then
+        local metrics_ok, metrics_err = ngx.timer.every(2, collect_gpu_metrics)
+        if not metrics_ok then
+            ngx.log(ngx.ERR, "Failed to create GPU metrics timer: ", metrics_err)
+        else
+            ngx.log(ngx.INFO, "GPU metrics collection timer started")
+        end
     end
 }
 
@@ -623,6 +733,83 @@ server {
             }
             
             ngx.say(cjson.encode(gpu_config))
+        }
+    }
+    
+    # Custom endpoint for UI to get GPU and CPU metrics
+    location /api/ui/gpu-metrics {
+        default_type application/json;
+        content_by_lua_block {
+            local cjson = require "cjson"
+            local gpu_metrics = ngx.shared.gpu_metrics
+            
+            -- Get GPU configuration from template
+            local gpu_config = {
+                groups = {
+{% for group in gpu_groups %}
+                    {
+                        name = "{{ group.name }}",
+                        devices = {
+{% for device in group.devices %}
+                            { index = {{ device.index }} },
+{% endfor %}
+                        }
+                    },
+{% endfor %}
+                },
+                instance_mapping = {
+{% for instance in ollama_instances %}
+                    ["polyllama{{ instance.number }}"] = {
+                        gpu_group_index = {{ instance.gpu_group_index if instance.gpu_indices else -1 }},
+                        has_gpu = {{ "true" if instance.gpu_indices else "false" }}
+                    },
+{% endfor %}
+                }
+            }
+            
+            local result = {
+                metrics = {},
+                timestamp = ngx.time()
+            }
+            
+            -- Collect metrics for each instance
+            for instance_name, config in pairs(gpu_config.instance_mapping) do
+                if config.has_gpu and config.gpu_group_index >= 0 and gpu_config.groups[config.gpu_group_index + 1] then
+                    -- GPU instance - collect GPU metrics
+                    local group = gpu_config.groups[config.gpu_group_index + 1]
+                    local instance_metrics = {
+                        instance = instance_name,
+                        type = "gpu",
+                        group_name = group.name,
+                        devices = {}
+                    }
+                    
+                    for _, device in ipairs(group.devices) do
+                        local metrics_json = gpu_metrics:get("gpu:" .. device.index)
+                        if metrics_json then
+                            local metrics = cjson.decode(metrics_json)
+                            metrics.index = device.index
+                            table.insert(instance_metrics.devices, metrics)
+                        end
+                    end
+                    
+                    table.insert(result.metrics, instance_metrics)
+                else
+                    -- CPU instance - get CPU metrics
+                    local cpu_metrics_json = gpu_metrics:get("cpu:" .. instance_name)
+                    if cpu_metrics_json then
+                        local cpu_data = cjson.decode(cpu_metrics_json)
+                        local instance_metrics = {
+                            instance = instance_name,
+                            type = "cpu",
+                            cpu_metrics = cpu_data
+                        }
+                        table.insert(result.metrics, instance_metrics)
+                    end
+                end
+            end
+            
+            ngx.say(cjson.encode(result))
         }
     }
 

--- a/stack/ollama/Dockerfile
+++ b/stack/ollama/Dockerfile
@@ -29,6 +29,10 @@ ENV DEBIAN_FRONTEND=
 COPY startServices.sh /root/startServices.sh
 RUN chmod +x /root/startServices.sh
 
-EXPOSE 11434
+# Copy GPU metrics server
+COPY gpu_metrics_server.py /root/gpu_metrics_server.py
+RUN chmod +x /root/gpu_metrics_server.py
+
+EXPOSE 11434 11435
 
 ENTRYPOINT ["/root/startServices.sh"]

--- a/stack/ollama/gpu_metrics_server.py
+++ b/stack/ollama/gpu_metrics_server.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+GPU Metrics Server - Runs in each Ollama container to expose GPU metrics
+"""
+import json
+import subprocess
+import os
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.parse import urlparse
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        """Handle GET requests for GPU metrics"""
+        parsed_path = urlparse(self.path)
+        
+        if parsed_path.path == '/metrics/gpu':
+            try:
+                # Get GPU metrics using nvidia-smi
+                metrics = self.get_gpu_metrics()
+                
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(json.dumps(metrics).encode())
+            except Exception as e:
+                self.send_error(500, f"Error collecting metrics: {str(e)}")
+        else:
+            self.send_error(404, "Not found")
+    
+    def get_gpu_metrics(self):
+        """Collect GPU metrics using nvidia-smi"""
+        metrics = []
+        
+        # Get CUDA_VISIBLE_DEVICES to know which GPUs we have access to
+        cuda_devices = os.environ.get('CUDA_VISIBLE_DEVICES', '')
+        if not cuda_devices:
+            return metrics
+        
+        # Parse GPU indices
+        gpu_indices = [int(idx.strip()) for idx in cuda_devices.split(',') if idx.strip()]
+        
+        for gpu_idx in gpu_indices:
+            try:
+                # Run nvidia-smi for this specific GPU
+                cmd = [
+                    'nvidia-smi',
+                    '--id=' + str(gpu_idx),
+                    '--query-gpu=index,memory.used,memory.total,utilization.gpu,temperature.gpu,power.draw',
+                    '--format=csv,noheader,nounits'
+                ]
+                
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                output = result.stdout.strip()
+                
+                if output:
+                    # Parse CSV output
+                    parts = [p.strip() for p in output.split(',')]
+                    if len(parts) >= 6:
+                        metrics.append({
+                            'index': int(parts[0]),
+                            'memory_used': float(parts[1]),
+                            'memory_total': float(parts[2]),
+                            'gpu_utilization': float(parts[3]),
+                            'temperature': float(parts[4]),
+                            'power_draw': float(parts[5]) if parts[5] != '[N/A]' else None,
+                            'timestamp': None  # Will be set by nginx
+                        })
+            except Exception as e:
+                print(f"Error getting metrics for GPU {gpu_idx}: {e}")
+        
+        return metrics
+    
+    def log_message(self, format, *args):
+        """Suppress request logging"""
+        pass
+
+def run_server(port=11435):
+    """Run the metrics HTTP server"""
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, MetricsHandler)
+    print(f"GPU Metrics server listening on port {port}")
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run_server()

--- a/stack/ollama/startServices.sh
+++ b/stack/ollama/startServices.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Start GPU metrics server in the background
+echo "Starting GPU metrics server on port 11435..."
+python3 /root/gpu_metrics_server.py &
+
 # Start Ollama in the background on port 11434
 echo "Starting Ollama service on port 11434..."
 OLLAMA_HOST=0.0.0.0:11434 /bin/ollama serve 2>&1 | grep -v '\[GIN\]'

--- a/stack/router/app/app/components/CPUMetrics.tsx
+++ b/stack/router/app/app/components/CPUMetrics.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+interface CPUMetricsData {
+  memory_used: number
+  memory_total: number
+  temperature?: number
+  is_cpu_instance: boolean
+  timestamp: number
+}
+
+interface CPUMetricsProps {
+  metrics?: CPUMetricsData
+}
+
+export default function CPUMetrics({ metrics }: CPUMetricsProps) {
+  if (!metrics) {
+    return (
+      <div className="bg-gray-50 rounded-md p-4 border border-gray-200">
+        <div className="text-xs text-gray-500 text-center py-2">
+          Loading CPU metrics...
+        </div>
+      </div>
+    )
+  }
+
+  const memoryPercent = (metrics.memory_used / metrics.memory_total) * 100
+
+  return (
+    <div className="bg-gray-50 rounded-md p-4 border border-gray-200">
+      <div className="font-medium text-sm text-gray-800 mb-3">CPU Instance</div>
+      
+      <div className="space-y-2">
+        {/* Memory Usage */}
+        <div>
+          <div className="flex justify-between text-xs mb-1">
+            <span className="text-gray-600">Memory</span>
+            <span className="font-medium">
+              {(metrics.memory_used / 1024).toFixed(1)}GB / {(metrics.memory_total / 1024).toFixed(1)}GB
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div 
+              className="bg-blue-600 h-2 rounded-full transition-all duration-500"
+              style={{ width: `${memoryPercent}%` }}
+            />
+          </div>
+        </div>
+        
+        {/* Temperature if available */}
+        {metrics.temperature && (
+          <div className="text-xs text-gray-600">
+            🌡️ {metrics.temperature.toFixed(0)}°C
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/stack/router/app/app/components/FlowChart.tsx
+++ b/stack/router/app/app/components/FlowChart.tsx
@@ -94,9 +94,10 @@ export default function FlowChart({ instances, instanceStatuses, runningModels, 
             const status = instanceStatuses[instance.name] || { status: 'offline', name: instance.name }
             const { groupName, devices } = getGPUGroupInfo(instance.name)
             
-            // Get CPU metrics if this is a CPU instance
+            // Get metrics for this instance
             const instanceMetrics = metrics[instance.name]
             const cpuMetrics = instanceMetrics?.type === 'cpu' ? instanceMetrics.cpu_metrics : undefined
+            const gpuMetrics = instanceMetrics?.type === 'gpu' ? instanceMetrics.devices : undefined
 
             return (
               <PolyLlamaInstance
@@ -107,6 +108,7 @@ export default function FlowChart({ instances, instanceStatuses, runningModels, 
                 modelContexts={modelContexts}
                 gpuGroupName={groupName !== 'CPU-only' ? groupName : undefined}
                 gpuDevices={devices}
+                gpuMetrics={gpuMetrics}
                 cpuMetrics={cpuMetrics}
                 onUnloadModel={handleUnloadModel}
               />

--- a/stack/router/app/app/components/GPUDevice.tsx
+++ b/stack/router/app/app/components/GPUDevice.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useGPUMetrics } from '../hooks/useGPUMetrics'
+
 export interface GPUDeviceInfo {
   index: number;
   name: string;
@@ -8,12 +10,43 @@ export interface GPUDeviceInfo {
 
 interface GPUDeviceProps {
   device: GPUDeviceInfo;
+  instanceName?: string;
 }
 
-export default function GPUDevice({ device }: GPUDeviceProps) {
+export default function GPUDevice({ device, instanceName }: GPUDeviceProps) {
+  // Don't pass instanceName to get all metrics, then filter
+  const { metrics: allMetrics } = useGPUMetrics()
+  
+  // Get metrics for this specific instance
+  const instanceMetrics = instanceName && allMetrics ? allMetrics[instanceName] : undefined
+  
+  // Find metrics for this specific device
+  const deviceMetrics = instanceMetrics?.devices && Array.isArray(instanceMetrics.devices) 
+    ? instanceMetrics.devices.find(m => m.index === device.index)
+    : undefined
+  
+  // Calculate percentages and colors
+  const memoryPercent = deviceMetrics 
+    ? (deviceMetrics.memory_used / deviceMetrics.memory_total) * 100 
+    : 0
+    
+  const getTemperatureColor = (temp?: number) => {
+    if (!temp) return 'text-gray-500'
+    if (temp < 60) return 'text-green-600'
+    if (temp < 75) return 'text-yellow-600'
+    return 'text-red-600'
+  }
+  
+  const getUtilizationColor = (util?: number) => {
+    if (!util) return 'bg-gray-200'
+    if (util < 50) return 'bg-green-500'
+    if (util < 80) return 'bg-yellow-500'
+    return 'bg-red-500'
+  }
+
   return (
     <div className="bg-gray-50 rounded-md p-4 border border-gray-200">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-start mb-3">
         <div>
           <div className="font-medium text-sm text-gray-800">{device.name}</div>
           <div className="text-xs text-gray-600 font-mono mt-1">PCI: {device.pci_bus}</div>
@@ -22,6 +55,54 @@ export default function GPUDevice({ device }: GPUDeviceProps) {
           Device {device.index}
         </div>
       </div>
+      
+      {deviceMetrics ? (
+        <div className="space-y-2 mt-3">
+          {/* VRAM Usage */}
+          <div>
+            <div className="flex justify-between text-xs mb-1">
+              <span className="text-gray-600">VRAM</span>
+              <span className="font-medium">
+                {(deviceMetrics.memory_used / 1024).toFixed(1)}GB / {(deviceMetrics.memory_total / 1024).toFixed(1)}GB
+              </span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div 
+                className="bg-blue-600 h-2 rounded-full transition-all duration-500"
+                style={{ width: `${memoryPercent}%` }}
+              />
+            </div>
+          </div>
+          
+          {/* GPU Utilization */}
+          <div className="flex justify-between items-center">
+            <span className="text-xs text-gray-600">GPU</span>
+            <div className="flex items-center gap-2">
+              <div className={`w-16 h-1.5 rounded-full ${getUtilizationColor(deviceMetrics.gpu_utilization)}`}>
+                <div 
+                  className="h-full bg-current rounded-full"
+                  style={{ width: `${deviceMetrics.gpu_utilization}%` }}
+                />
+              </div>
+              <span className="text-xs font-medium">{deviceMetrics.gpu_utilization}%</span>
+            </div>
+          </div>
+          
+          {/* Temperature & Power */}
+          <div className="flex justify-between text-xs">
+            <span className={getTemperatureColor(deviceMetrics.temperature)}>
+              🌡️ {deviceMetrics.temperature}°C
+            </span>
+            <span className="text-gray-600">
+              ⚡ {deviceMetrics.power_draw?.toFixed(0)}W
+            </span>
+          </div>
+        </div>
+      ) : (
+        <div className="text-xs text-gray-500 text-center py-2">
+          Loading metrics...
+        </div>
+      )}
     </div>
   )
 }

--- a/stack/router/app/app/components/GPUDevice.tsx
+++ b/stack/router/app/app/components/GPUDevice.tsx
@@ -1,29 +1,27 @@
 'use client'
 
-import { useGPUMetrics } from '../hooks/useGPUMetrics'
-
 export interface GPUDeviceInfo {
   index: number;
   name: string;
   pci_bus: string;
 }
 
-interface GPUDeviceProps {
-  device: GPUDeviceInfo;
-  instanceName?: string;
+interface GPUMetrics {
+  index: number
+  memory_used: number
+  memory_total: number
+  gpu_utilization: number
+  temperature: number
+  power_draw: number
+  timestamp: number
 }
 
-export default function GPUDevice({ device, instanceName }: GPUDeviceProps) {
-  // Don't pass instanceName to get all metrics, then filter
-  const { metrics: allMetrics } = useGPUMetrics()
-  
-  // Get metrics for this specific instance
-  const instanceMetrics = instanceName && allMetrics ? allMetrics[instanceName] : undefined
-  
-  // Find metrics for this specific device
-  const deviceMetrics = instanceMetrics?.devices && Array.isArray(instanceMetrics.devices) 
-    ? instanceMetrics.devices.find(m => m.index === device.index)
-    : undefined
+interface GPUDeviceProps {
+  device: GPUDeviceInfo;
+  deviceMetrics?: GPUMetrics;
+}
+
+export default function GPUDevice({ device, deviceMetrics }: GPUDeviceProps) {
   
   // Calculate percentages and colors
   const memoryPercent = deviceMetrics 

--- a/stack/router/app/app/components/PolyLlamaInstance.tsx
+++ b/stack/router/app/app/components/PolyLlamaInstance.tsx
@@ -12,6 +12,16 @@ interface CPUMetricsData {
   timestamp: number
 }
 
+interface GPUMetrics {
+  index: number
+  memory_used: number
+  memory_total: number
+  gpu_utilization: number
+  temperature: number
+  power_draw: number
+  timestamp: number
+}
+
 interface PolyLlamaInstanceProps {
   instance: Instance;
   status: any;
@@ -19,6 +29,7 @@ interface PolyLlamaInstanceProps {
   modelContexts: Record<string, number>;
   gpuGroupName?: string;
   gpuDevices?: GPUDeviceInfo[];
+  gpuMetrics?: GPUMetrics[];
   cpuMetrics?: CPUMetricsData;
   onUnloadModel: (modelName: string, instanceName: string) => void;
 }
@@ -30,6 +41,7 @@ export default function PolyLlamaInstance({
   modelContexts,
   gpuGroupName,
   gpuDevices,
+  gpuMetrics,
   cpuMetrics,
   onUnloadModel
 }: PolyLlamaInstanceProps) {
@@ -110,13 +122,16 @@ export default function PolyLlamaInstance({
         <div className="bg-white rounded-xl p-6 shadow-sm">
           <div className="text-sm text-gray-600 mb-3 font-medium">GPU Devices</div>
           <div className="space-y-2">
-            {gpuDevices.map((device) => (
-              <GPUDevice 
-                key={device.index} 
-                device={device} 
-                instanceName={instance.name}
-              />
-            ))}
+            {gpuDevices.map((device) => {
+              const deviceMetrics = gpuMetrics?.find(m => m.index === device.index)
+              return (
+                <GPUDevice 
+                  key={device.index} 
+                  device={device} 
+                  deviceMetrics={deviceMetrics}
+                />
+              )
+            })}
           </div>
         </div>
       ) : cpuMetrics ? (

--- a/stack/router/app/app/components/PolyLlamaInstance.tsx
+++ b/stack/router/app/app/components/PolyLlamaInstance.tsx
@@ -2,6 +2,15 @@
 
 import { Instance, RunningModels } from '../types'
 import GPUDevice, { GPUDeviceInfo } from './GPUDevice'
+import CPUMetrics from './CPUMetrics'
+
+interface CPUMetricsData {
+  memory_used: number
+  memory_total: number
+  temperature?: number
+  is_cpu_instance: boolean
+  timestamp: number
+}
 
 interface PolyLlamaInstanceProps {
   instance: Instance;
@@ -10,6 +19,7 @@ interface PolyLlamaInstanceProps {
   modelContexts: Record<string, number>;
   gpuGroupName?: string;
   gpuDevices?: GPUDeviceInfo[];
+  cpuMetrics?: CPUMetricsData;
   onUnloadModel: (modelName: string, instanceName: string) => void;
 }
 
@@ -20,6 +30,7 @@ export default function PolyLlamaInstance({
   modelContexts,
   gpuGroupName,
   gpuDevices,
+  cpuMetrics,
   onUnloadModel
 }: PolyLlamaInstanceProps) {
   const instanceModels = Object.keys(runningModels).filter(model =>
@@ -31,17 +42,15 @@ export default function PolyLlamaInstance({
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       {/* Column 1: Instance details */}
       <div className="bg-white rounded-xl overflow-hidden shadow-sm transition-all hover:shadow-md">
-        {/* Header */}
+        {/* Header - show CPU badge for CPU instances */}
         <div className="bg-gradient-to-r from-gray-700 to-gray-800 text-white px-6 py-5 flex items-center justify-between">
           <div className="flex items-center gap-2 text-lg font-semibold">
             <span className={`w-2.5 h-2.5 rounded-full ${isOnline ? 'bg-success animate-pulse-soft' : 'bg-danger'}`}></span>
             <span>{instance.name}</span>
           </div>
-          {gpuGroupName && (
-            <span className="text-xs bg-white/20 px-3 py-1 rounded">
-              {gpuGroupName}
-            </span>
-          )}
+          <span className="text-xs bg-white/20 px-3 py-1 rounded">
+            {gpuGroupName || 'CPU'}
+          </span>
         </div>
 
         {/* Content */}
@@ -96,17 +105,26 @@ export default function PolyLlamaInstance({
         </div>
       </div>
 
-      {/* Column 2: GPU Devices */}
-      {gpuDevices && gpuDevices.length > 0 && (
+      {/* Column 2: GPU Devices OR CPU Metrics */}
+      {gpuDevices && gpuDevices.length > 0 ? (
         <div className="bg-white rounded-xl p-6 shadow-sm">
           <div className="text-sm text-gray-600 mb-3 font-medium">GPU Devices</div>
           <div className="space-y-2">
             {gpuDevices.map((device) => (
-              <GPUDevice key={device.index} device={device} />
+              <GPUDevice 
+                key={device.index} 
+                device={device} 
+                instanceName={instance.name}
+              />
             ))}
           </div>
         </div>
-      )}
+      ) : cpuMetrics ? (
+        <div className="bg-white rounded-xl p-6 shadow-sm">
+          <div className="text-sm text-gray-600 mb-3 font-medium">System Resources</div>
+          <CPUMetrics metrics={cpuMetrics} />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/stack/router/app/app/hooks/useGPUMetrics.ts
+++ b/stack/router/app/app/hooks/useGPUMetrics.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect } from 'react'
+
+interface GPUMetrics {
+  index: number
+  memory_used: number
+  memory_total: number
+  gpu_utilization: number
+  temperature: number
+  power_draw: number
+  timestamp: number
+}
+
+interface CPUMetrics {
+  memory_used: number
+  memory_total: number
+  temperature?: number
+  is_cpu_instance: boolean
+  timestamp: number
+}
+
+interface InstanceMetrics {
+  instance: string
+  type: 'gpu' | 'cpu'
+  group_name?: string
+  devices?: GPUMetrics[]
+  cpu_metrics?: CPUMetrics
+}
+
+interface GPUMetricsResponse {
+  metrics: InstanceMetrics[]
+  timestamp: number
+}
+
+export function useGPUMetrics(instanceName?: string) {
+  const [metrics, setMetrics] = useState<Record<string, InstanceMetrics>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchMetrics = async () => {
+      try {
+        const response = await fetch('/api/ui/gpu-metrics')
+        if (!response.ok) throw new Error('Failed to fetch metrics')
+        
+        const data: GPUMetricsResponse = await response.json()
+        const metricsMap: Record<string, InstanceMetrics> = {}
+        
+        data.metrics.forEach((m: InstanceMetrics) => {
+          metricsMap[m.instance] = m
+        })
+        
+        setMetrics(metricsMap)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchMetrics()
+    const interval = setInterval(fetchMetrics, 2000) // Update every 2 seconds
+    
+    return () => clearInterval(interval)
+  }, [])
+
+  if (instanceName) {
+    return {
+      metrics: metrics[instanceName],
+      loading,
+      error
+    }
+  }
+
+  return { metrics, loading, error }
+}

--- a/tests/test_artifacts/nginx.conf
+++ b/tests/test_artifacts/nginx.conf
@@ -7,6 +7,9 @@ lua_package_path "/usr/local/openresty/lualib/?.lua;;";
 # Create a shared dictionary to store environment variables
 lua_shared_dict env_vars 1m;
 
+# Create a shared dictionary to store GPU metrics
+lua_shared_dict gpu_metrics 5m;
+
 # Initialize environment variables in the main Nginx process
 init_by_lua_block {
     local env_vars = ngx.shared.env_vars
@@ -23,12 +26,121 @@ init_by_lua_block {
 init_worker_by_lua_block {
     local model_router = require "model_router"
     local env_vars = ngx.shared.env_vars
+    local cjson = require "cjson"
     
     -- Initialize model router
     
     local ok, err = ngx.timer.every(3, model_router.update_model_mappings)
     if not ok then
         ngx.log(ngx.ERR, "Failed to create timer: ", err)
+    end
+    
+    -- Function to collect GPU metrics
+    local function collect_gpu_metrics()
+        local gpu_metrics = ngx.shared.gpu_metrics
+        local http = require "resty.http"
+        
+        -- Instance to GPU mapping
+        local instance_gpu_mapping = {
+            ["polyllama1"] = {
+                gpu_indices = { 0,1,2 },
+                gpu_group_index = 0
+            },
+            ["polyllama2"] = {
+                gpu_indices = { 3 },
+                gpu_group_index = 1
+            },
+        }
+        
+        -- Collect metrics from each instance's metrics endpoint
+        for instance_name, gpu_info in pairs(instance_gpu_mapping) do
+            local httpc = http.new()
+            httpc:set_timeout(2000)  -- 2 second timeout
+            
+            local res, err = httpc:request_uri("http://" .. instance_name .. ":11435/metrics/gpu", {
+                method = "GET"
+            })
+            
+            if res and res.status == 200 then
+                local success, device_metrics = pcall(cjson.decode, res.body)
+                if success and device_metrics then
+                    -- Store metrics for each GPU device
+                    for _, metric in ipairs(device_metrics) do
+                        metric.timestamp = ngx.time()
+                        gpu_metrics:set("gpu:" .. metric.index, cjson.encode(metric), 10)
+                    end
+                else
+                    ngx.log(ngx.ERR, "Failed to parse metrics from " .. instance_name)
+                end
+            else
+                ngx.log(ngx.ERR, "Failed to fetch metrics from " .. instance_name .. ": " .. (err or "unknown error"))
+            end
+        end
+        
+        -- Collect CPU metrics for CPU-only instances
+        local instance_mapping = {
+            ["polyllama1"] = {
+                gpu_group_index = 0,
+                has_gpu = true
+            },
+            ["polyllama2"] = {
+                gpu_group_index = 1,
+                has_gpu = true
+            },
+        }
+        
+        -- Collect CPU metrics for CPU-only instances
+        for instance_name, config in pairs(instance_mapping) do
+            if not config.has_gpu then
+                -- Get CPU and memory info
+                local cpu_handle = io.popen("grep 'cpu ' /proc/stat 2>/dev/null | head -n1")
+                local mem_handle = io.popen("free -m 2>/dev/null | grep '^Mem:'")
+                
+                if cpu_handle and mem_handle then
+                    local cpu_output = cpu_handle:read("*a")
+                    local mem_output = mem_handle:read("*a")
+                    cpu_handle:close()
+                    mem_handle:close()
+                    
+                    -- Parse memory usage
+                    local mem_total, mem_used = mem_output:match("Mem:%s+(%d+)%s+(%d+)")
+                    
+                    if mem_total then
+                        -- Get CPU temperature if available
+                        local temp = nil
+                        local temp_handle = io.popen("cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null")
+                        if temp_handle then
+                            local temp_output = temp_handle:read("*a")
+                            temp_handle:close()
+                            if temp_output and temp_output ~= "" then
+                                temp = tonumber(temp_output) / 1000  -- Convert from millidegrees
+                            end
+                        end
+                        
+                        local metrics = {
+                            memory_used = tonumber(mem_used),
+                            memory_total = tonumber(mem_total),
+                            temperature = temp,
+                            is_cpu_instance = true,
+                            timestamp = ngx.time()
+                        }
+                        
+                        -- Store CPU metrics
+                        gpu_metrics:set("cpu:" .. instance_name, cjson.encode(metrics), 10)
+                    end
+                end
+            end
+        end
+    end
+    
+    -- Set up timer to collect metrics every 2 seconds (only on first worker)
+    if ngx.worker.id() == 0 then
+        local metrics_ok, metrics_err = ngx.timer.every(2, collect_gpu_metrics)
+        if not metrics_ok then
+            ngx.log(ngx.ERR, "Failed to create GPU metrics timer: ", metrics_err)
+        else
+            ngx.log(ngx.INFO, "GPU metrics collection timer started")
+        end
     end
 }
 
@@ -618,6 +730,85 @@ server {
             }
             
             ngx.say(cjson.encode(gpu_config))
+        }
+    }
+    
+    # Custom endpoint for UI to get GPU and CPU metrics
+    location /api/ui/gpu-metrics {
+        default_type application/json;
+        content_by_lua_block {
+            local cjson = require "cjson"
+            local gpu_metrics = ngx.shared.gpu_metrics
+            
+            -- Get GPU configuration from template
+            local gpu_config = {
+                groups = {
+                    {
+                        name = "NVIDIA GeForce RTX 4090",
+                        devices = {
+                        }
+                    },
+                    {
+                        name = "NVIDIA RTX 6000 Ada Generation",
+                        devices = {
+                        }
+                    },
+                },
+                instance_mapping = {
+                    ["polyllama1"] = {
+                        gpu_group_index = 0,
+                        has_gpu = true
+                    },
+                    ["polyllama2"] = {
+                        gpu_group_index = 1,
+                        has_gpu = true
+                    },
+                }
+            }
+            
+            local result = {
+                metrics = {},
+                timestamp = ngx.time()
+            }
+            
+            -- Collect metrics for each instance
+            for instance_name, config in pairs(gpu_config.instance_mapping) do
+                if config.has_gpu and config.gpu_group_index >= 0 and gpu_config.groups[config.gpu_group_index + 1] then
+                    -- GPU instance - collect GPU metrics
+                    local group = gpu_config.groups[config.gpu_group_index + 1]
+                    local instance_metrics = {
+                        instance = instance_name,
+                        type = "gpu",
+                        group_name = group.name,
+                        devices = {}
+                    }
+                    
+                    for _, device in ipairs(group.devices) do
+                        local metrics_json = gpu_metrics:get("gpu:" .. device.index)
+                        if metrics_json then
+                            local metrics = cjson.decode(metrics_json)
+                            metrics.index = device.index
+                            table.insert(instance_metrics.devices, metrics)
+                        end
+                    end
+                    
+                    table.insert(result.metrics, instance_metrics)
+                else
+                    -- CPU instance - get CPU metrics
+                    local cpu_metrics_json = gpu_metrics:get("cpu:" .. instance_name)
+                    if cpu_metrics_json then
+                        local cpu_data = cjson.decode(cpu_metrics_json)
+                        local instance_metrics = {
+                            instance = instance_name,
+                            type = "cpu",
+                            cpu_metrics = cpu_data
+                        }
+                        table.insert(result.metrics, instance_metrics)
+                    end
+                end
+            end
+            
+            ngx.say(cjson.encode(result))
         }
     }
 


### PR DESCRIPTION
## Summary
- Implements real-time GPU metrics collection and display in the UI
- Adds support for monitoring GPU utilization, VRAM usage, temperature, and power consumption
- Includes CPU metrics for CPU-only instances

## Implementation Details

### Backend Changes
1. **Metrics Collection Architecture**
   - Created Python metrics server that runs in each Ollama container on port 11435
   - Uses nvidia-smi to collect GPU metrics for assigned GPUs
   - Router aggregates metrics from all instances via HTTP

2. **Nginx Configuration**
   - Added shared memory zone `gpu_metrics` for storing metrics
   - Implemented metrics collection timer that polls instances every 2 seconds
   - Created `/api/ui/gpu-metrics` endpoint for frontend consumption

### Frontend Changes
1. **React Components**
   - Added `useGPUMetrics` hook for real-time metric updates
   - Enhanced `GPUDevice` component with metric displays (VRAM bar, GPU %, temp, power)
   - Created `CPUMetrics` component for CPU-only instances
   - Updated `PolyLlamaInstance` and `FlowChart` to handle metrics data

2. **Visual Features**
   - VRAM usage progress bar with smooth animations
   - Color-coded temperature indicators (green < 60°C, yellow < 75°C, red ≥ 75°C)
   - GPU utilization with color-coded bar
   - Power consumption display

## Technical Approach
Since the nginx router container doesn't have access to nvidia-smi, we run a metrics server in each Ollama container (which has GPU access) and aggregate the metrics in the router. This provides accurate, real-time metrics without complex host mounting.

## Testing
- Tested with multi-GPU configuration (RTX 4090 + RTX 6000 Ada)
- Verified metrics update every 2 seconds
- Confirmed graceful handling of missing metrics

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)